### PR TITLE
Security: Fix SQL injection in cast() function

### DIFF
--- a/src/adaptors/sequelizer.ts
+++ b/src/adaptors/sequelizer.ts
@@ -589,10 +589,25 @@ export class SequelizerAdaptor {
         return `CEIL(${args[0]})`;
       case 'cast':
         // OData V4 cast(expression, type) -> SQL CAST(expression AS type)
-        // Note: The type argument in OData is a string literal, which will be quoted in expressionToSql.
-        // We need to unquote it.
-        const typeArg = args[1].replace(/^'|'$/g, '');
-        return `CAST(${args[0]} AS ${typeArg})`;
+        // Validate the type argument against a strict allowlist to prevent SQL injection.
+        const ALLOWED_CAST_TYPES = [
+          'int', 'integer', 'bigint', 'smallint', 'tinyint',
+          'float', 'real', 'double', 'double precision',
+          'decimal', 'numeric',
+          'varchar', 'char', 'text', 'nvarchar', 'nchar', 'ntext',
+          'date', 'time', 'datetime', 'datetime2', 'timestamp', 'timestamptz',
+          'boolean', 'bool', 'bit',
+          'uuid', 'guid',
+          'json', 'jsonb',
+          'binary', 'varbinary', 'blob',
+        ];
+        const rawTypeArg = args[1].replace(/^'|'$/g, '').trim().toLowerCase();
+        // Also allow types with precision like decimal(10,2) or varchar(255)
+        const baseType = rawTypeArg.replace(/\([\d,\s]+\)$/, '');
+        if (!ALLOWED_CAST_TYPES.includes(baseType)) {
+          throw new BadRequestError(`Invalid CAST type: ${rawTypeArg}. Allowed types: ${ALLOWED_CAST_TYPES.join(', ')}`);
+        }
+        return `CAST(${args[0]} AS ${rawTypeArg})`;
       default:
         throw new BadRequestError(`Unsupported function: ${func.name}`);
     }


### PR DESCRIPTION
## Description
The `cast()` OData function in `src/adaptors/sequelizer.ts` (line 594-595) allows SQL injection. The type argument from user input is stripped of outer quotes and interpolated directly into raw SQL via Sequelize's `literal()`.

```typescript
const typeArg = args[1].replace(/^'|'$/g, '');
return `CAST(${args[0]} AS ${typeArg})`;
```

### Attack Vector
```
$filter=cast(id, 'int) UNION SELECT username,password FROM credentials--') eq 1
```

### Fix
Validates the cast type argument against a strict allowlist of known SQL types (int, varchar, decimal, date, etc.). Types with precision like `decimal(10,2)` and `varchar(255)` are also supported.