### PR TITLE
Security: Fix double URL decoding vulnerability in decodeUrl

### DIFF
--- a/src/serializers/decodeUrl.ts
+++ b/src/serializers/decodeUrl.ts
@@ -10,6 +10,7 @@ interface IDecodeUrlResponse {
 export const decodeUrl = (url: string): IDecodeUrlResponse => {
   validatePath(url);
   const trimmedUrl = url.trim();
+  // Decode only once to prevent double-decoding bypass attacks
   const formatedUrl = trimmedUrl.startsWith('/')
     ? decodeURIComponent(trimmedUrl.substring(1))
     : decodeURIComponent(trimmedUrl);
@@ -19,12 +20,13 @@ export const decodeUrl = (url: string): IDecodeUrlResponse => {
   const path = urlParts[0];
   const basepath = path.split('/')[0];
 
-  const removeTailingSlash = formatedUrl.endsWith('/')
-    ? decodeURIComponent(formatedUrl.slice(0, -1))
-    : decodeURIComponent(formatedUrl);
+  // Remove trailing slash without re-decoding
+  const fullPath = formatedUrl.endsWith('/')
+    ? formatedUrl.slice(0, -1)
+    : formatedUrl;
 
   return {
-    fullPath: removeTailingSlash,
+    fullPath,
     path,
     queryParams: parse(queryParams) || {},
     basepath,


### PR DESCRIPTION
## Description
`src/serializers/decodeUrl.ts` calls `decodeURIComponent()` twice on the URL -- once when stripping the leading slash (line 13-14), and again when removing the trailing slash (line 22-24). This enables double-encoding bypass attacks where `%2527` decodes to `%27` then to `'`.

### Fix
Removes the second `decodeURIComponent` call. The trailing slash removal now operates on the already-decoded string without re-decoding.