### PR TITLE
Fix: Info disclosure in error responses and InternalServerError returning 404

### DIFF
--- a/src/routers/openRouter.ts
+++ b/src/routers/openRouter.ts
@@ -80,11 +80,8 @@ export class OpenRouter {
       response.meta.totalExecutionTime = executionTime;
       return response;
     } catch (error: unknown) {
-      throw new InternalServerError(
-        'Error processing request',
-        { message: (error as Error).message, stack: (error as Error).stack },
-        (error as Error).stack,
-      );
+      Logger.getLogger().error('Error processing request', error);
+      throw new InternalServerError('Error processing request');
     }
   }
 
@@ -132,11 +129,8 @@ export class OpenRouter {
 
       return response;
     } catch (error: unknown) {
-      throw new InternalServerError(
-        'Error processing raw query',
-        { message: (error as Error).message, stack: (error as Error).stack },
-        (error as Error).stack,
-      );
+      Logger.getLogger().error('Error processing raw query', error);
+      throw new InternalServerError('Error processing raw query');
     }
   }
 

--- a/src/serializers/queryConverter.ts
+++ b/src/serializers/queryConverter.ts
@@ -104,10 +104,7 @@ const convertColumnNameToColumnIdentifier = (
       });
       if (!relation) {
         throw new NotFoundError(
-          `Navigation property '${expand.table}' not found on table '${rawData.table}'. ` +
-            `Available navigation properties: ${relationMetadata
-              .map(r => r.propertyKey)
-              .join(', ')}`,
+          `Navigation property '${expand.table}' not found`,
         );
       }
       // Update expand.table to use the actual model name for recursive processing

--- a/src/utils/error-management/error-classes/internalServerError.ts
+++ b/src/utils/error-management/error-classes/internalServerError.ts
@@ -3,6 +3,6 @@ import { AppError } from '../appError';
 
 export class InternalServerError extends AppError {
   constructor(message: string, details?: any, stack?: string) {
-    super(ERROR_CODES.NOT_FOUND_ERROR, message, details, stack);
+    super(ERROR_CODES.INTERNAL_SERVER_ERROR, message, details, stack);
   }
 }


### PR DESCRIPTION
## Description
Three related issues:

1. **Stack traces in responses**: `src/routers/openRouter.ts` wraps all errors with full stack traces into the JSON response sent to clients.
2. **Wrong error code**: `InternalServerError` passes `ERROR_CODES.NOT_FOUND_ERROR` instead of `INTERNAL_SERVER_ERROR`, returning HTTP 404 instead of 500.
3. **Schema enumeration**: `queryConverter.ts` error messages list all available navigation properties, aiding attacker reconnaissance.

### Fix
- Log errors server-side, return generic message to client
- Use correct `INTERNAL_SERVER_ERROR` error code
- Remove schema enumeration from error messages