### PR TITLE
Security: Add expand depth limit and default query top

### DIFF
--- a/src/serializers/query/index.ts
+++ b/src/serializers/query/index.ts
@@ -141,7 +141,7 @@ class QueryParser {
     this.orderBy = parseOrderBy(rawSearchParams.orderBy, this.baseTableName);
     this.expand = parseExpand(rawSearchParams.expand);
     this.filter = parseFilter(rawSearchParams.filter, this.baseTableName);
-    this.top = rawSearchParams.top || this.options.defaultTop || 0;
+    this.top = rawSearchParams.top || this.options.defaultTop || 100;
     this.skip = rawSearchParams.skip || this.options.defaultSkip || 0;
     this.count = rawSearchParams.count === 'true'; // $count=true
     this.apply = parseApply(rawSearchParams.apply);

--- a/src/serializers/query/parseExpand.ts
+++ b/src/serializers/query/parseExpand.ts
@@ -1,7 +1,10 @@
 import { ExpandClause } from '../../types';
+import { BadRequestError } from '../../utils/error-management';
 import { parseFilter } from './parseFilter';
 import { parseOrderBy } from './parseOrderBy';
 import { parseSelect } from './parseSelect';
+
+const MAX_EXPAND_DEPTH = 4;
 
 interface RawExpandClause {
   table: string;
@@ -12,9 +15,14 @@ interface RawExpandClause {
   type: 'inner' | 'left' | 'right';
 }
 
-const parseExpand = (query: string) => {
+const parseExpand = (query: string, depth = 0) => {
+  if (depth > MAX_EXPAND_DEPTH) {
+    throw new BadRequestError(
+      `$expand nesting exceeds maximum depth of ${MAX_EXPAND_DEPTH}`,
+    );
+  }
   const parsedData = parseExpandSimple(query);
-  const fomattedData = formatParsedData(parsedData);
+  const fomattedData = formatParsedData(parsedData, depth);
   return fomattedData;
 };
 
@@ -176,12 +184,17 @@ function parseOptions(optionsString: string): any {
   return options;
 }
 
-function formatParsedData(parsedData: RawExpandClause[]): ExpandClause[] {
+function formatParsedData(parsedData: RawExpandClause[], depth = 0): ExpandClause[] {
   return parsedData.map((item: RawExpandClause) => {
     const select = parseSelect(item.select || '', item.table);
     const filter = parseFilter(item.filter || '', item.table);
     const orderBy = parseOrderBy(item.orderBy || '', item.table);
-    const expand = item.expand ? formatParsedData(item.expand) : undefined;
+    const expand = item.expand ? formatParsedData(item.expand, depth + 1) : undefined;
+    if (expand && depth + 1 > MAX_EXPAND_DEPTH) {
+      throw new BadRequestError(
+        `$expand nesting exceeds maximum depth of ${MAX_EXPAND_DEPTH}`,
+      );
+    }
     return {
       ...item,
       select,


### PR DESCRIPTION
## Description
Two resource exhaustion vectors:

1. **No \$expand depth limit**: `parseExpand.ts` recursively parses nested \$expand with no depth limit, enabling massive JOIN queries or stack overflow.
2. **No default \$top**: When not specified, default is 0 which becomes no limit, returning ALL rows.

### Fix
- Add `MAX_EXPAND_DEPTH = 4`, throwing `BadRequestError` for deeper nesting
- Change default \$top from 0 (unlimited) to 100