### PR TITLE
Fix: LIKE wildcard injection and broken notLike in boolean filter functions

### DIFF
--- a/src/adaptors/sequelizer.ts
+++ b/src/adaptors/sequelizer.ts
@@ -330,7 +330,13 @@ export class SequelizerAdaptor {
       }
 
       const field = this.buildExpression(args[0]);
-      const searchValue = this.buildExpression(args[1]);
+      const rawSearchValue = this.buildExpression(args[1]);
+
+      // Escape LIKE wildcards in the search value to prevent wildcard injection
+      const searchValue =
+        typeof rawSearchValue === 'string'
+          ? rawSearchValue.replace(/[%_\\]/g, '\\$&')
+          : rawSearchValue;
 
       // Determine if we're checking for true or false
       const checkForTrue =
@@ -339,13 +345,13 @@ export class SequelizerAdaptor {
       let likePattern: string;
       switch (funcName) {
         case 'contains':
-          likePattern = checkForTrue ? `%${searchValue}%` : `NOT LIKE '%${searchValue}%'`;
+          likePattern = `%${searchValue}%`;
           break;
         case 'startswith':
-          likePattern = checkForTrue ? `${searchValue}%` : `NOT LIKE '${searchValue}%'`;
+          likePattern = `${searchValue}%`;
           break;
         case 'endswith':
-          likePattern = checkForTrue ? `%${searchValue}` : `NOT LIKE '%${searchValue}'`;
+          likePattern = `%${searchValue}`;
           break;
         default:
           throw new BadRequestError(`Unsupported boolean function: ${funcName}`);
@@ -354,8 +360,7 @@ export class SequelizerAdaptor {
       if (checkForTrue) {
         return where(field, Op.like, likePattern);
       } else {
-        // For negative checks, use notLike
-        return where(field, Op.notLike, likePattern.replace(/NOT LIKE '?/, ''));
+        return where(field, Op.notLike, likePattern);
       }
     }
 


### PR DESCRIPTION
## Description
Two issues in boolean function handling (contains, startswith, endswith) in `src/adaptors/sequelizer.ts`:

1. **LIKE wildcards not escaped**: SQL wildcards (`%`, `_`) in search values are not escaped, allowing attackers to use `contains(name, '%')` to match all rows.
2. **Broken notLike regex**: Line 358 uses a malformed regex (`/NOT LIKE '?/`) to strip a prefix, causing incorrect behavior. The negative-check patterns also had raw SQL embedded.

### Fix
- Escape `%`, `_`, `\` in search values before building LIKE patterns
- Use `Op.notLike` directly with clean patterns instead of the broken regex approach