### PR TITLE
Fix: SQL injection prevention in sequelizer

### DIFF
--- a/src/adaptors/sequelizer.ts
+++ b/src/adaptors/sequelizer.ts
@@ -57,9 +57,45 @@ interface ISequelizeQuery {
   as?: string;
 }
 
+// Safe SQL identifier pattern: only allows alphanumeric, underscore, and dollar sign
+const SAFE_IDENTIFIER = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;
+
 export class SequelizerAdaptor {
   private sequelize: Sequelize;
   private modelCache = new Map<string, SequelizeModelController>();
+
+  /**
+   * Validate that a string is a safe SQL identifier (table name, column name, alias).
+   * Prevents SQL injection through identifier positions in literal() strings.
+   */
+  private validateSqlIdentifier(name: string, context: string): void {
+    if (!name || !SAFE_IDENTIFIER.test(name)) {
+      throw new BadRequestError(
+        `Invalid ${context}: '${name}'. Identifiers must contain only alphanumeric characters and underscores.`,
+      );
+    }
+  }
+
+  /**
+   * Safely escape a string value for use in a SQL literal.
+   * Uses single-quote doubling and rejects null bytes.
+   */
+  private escapeSqlString(value: string): string {
+    if (value.includes('\0')) {
+      throw new BadRequestError('String values must not contain null bytes');
+    }
+    return `'${value.replace(/'/g, "''")}'`;
+  }
+
+  /**
+   * Validate a numeric value for safe use in SQL.
+   */
+  private validateSqlNumber(value: number): string {
+    if (!Number.isFinite(value)) {
+      throw new BadRequestError(`Invalid numeric value: ${value}`);
+    }
+    return String(value);
+  }
 
   constructor(dbConfig: IDbConfig) {
     // For SQLite, use 'storage' instead of 'database'
@@ -330,7 +366,13 @@ export class SequelizerAdaptor {
       }
 
       const field = this.buildExpression(args[0]);
-      const searchValue = this.buildExpression(args[1]);
+      const rawSearchValue = this.buildExpression(args[1]);
+
+      // Escape LIKE wildcards in the search value to prevent wildcard injection
+      const searchValue =
+        typeof rawSearchValue === 'string'
+          ? rawSearchValue.replace(/[%_\\]/g, '\\$&')
+          : rawSearchValue;
 
       // Determine if we're checking for true or false
       const checkForTrue =
@@ -339,13 +381,13 @@ export class SequelizerAdaptor {
       let likePattern: string;
       switch (funcName) {
         case 'contains':
-          likePattern = checkForTrue ? `%${searchValue}%` : `NOT LIKE '%${searchValue}%'`;
+          likePattern = `%${searchValue}%`;
           break;
         case 'startswith':
-          likePattern = checkForTrue ? `${searchValue}%` : `NOT LIKE '${searchValue}%'`;
+          likePattern = `${searchValue}%`;
           break;
         case 'endswith':
-          likePattern = checkForTrue ? `%${searchValue}` : `NOT LIKE '%${searchValue}'`;
+          likePattern = `%${searchValue}`;
           break;
         default:
           throw new BadRequestError(`Unsupported boolean function: ${funcName}`);
@@ -354,8 +396,7 @@ export class SequelizerAdaptor {
       if (checkForTrue) {
         return where(field, Op.like, likePattern);
       } else {
-        // For negative checks, use notLike
-        return where(field, Op.notLike, likePattern.replace(/NOT LIKE '?/, ''));
+        return where(field, Op.notLike, likePattern);
       }
     }
 
@@ -377,10 +418,23 @@ export class SequelizerAdaptor {
       case 'in':
         return where(leftSide, Op.in, Array.isArray(rightSide) ? rightSide : [rightSide]);
       case 'has':
-        // OData V4 'has' operator is for enum flags.
-        // For now, we'll treat it as a bitwise AND check for integer flags.
-        // This is a simplification and might need refinement based on the actual DB schema.
-        return where(literal(`${leftSide} & ${rightSide}`), Op.eq, rightSide);
+        // OData V4 'has' operator is for enum flags (bitwise AND check).
+        // Restrict to simple field-to-integer comparisons to prevent SQL injection.
+        if (leftExpression.type !== 'field' || rightExpression.type !== 'literal') {
+          throw new BadRequestError(
+            "'has' operator only supports simple field-to-value comparisons (e.g., flags has 4)",
+          );
+        }
+        if (typeof rightSide !== 'number' || !Number.isInteger(rightSide)) {
+          throw new BadRequestError("'has' operator requires an integer right-hand value");
+        }
+        {
+          // Build safe literal using validated column name and integer value
+          const fieldName = leftExpression.field?.name || '';
+          this.validateSqlIdentifier(fieldName, 'column name');
+          const flagValue = Math.floor(rightSide);
+          return where(literal(`"${fieldName}" & ${flagValue}`), Op.eq, flagValue);
+        }
       default:
         // For simple field comparisons, use object notation
         if (leftExpression.type === 'field' && rightExpression.type === 'literal') {
@@ -414,17 +468,17 @@ export class SequelizerAdaptor {
       case 'field':
         // Check if this is a navigation path field
         if (expression.field?.navigationPath && expression.field?.table) {
-          // Use Sequelize's special syntax for joined table fields: $alias.column$
-          const alias = expression.field.navigationPath[0]; // Navigation property name
+          const alias = expression.field.navigationPath[0];
           const columnName = expression.field.name;
+          this.validateSqlIdentifier(alias, 'navigation property');
+          this.validateSqlIdentifier(columnName, 'column name');
           return col(`$${alias}.${columnName}$`);
         }
         // Simple field reference
+        this.validateSqlIdentifier(expression.field?.name || '', 'column name');
         return col(expression.field?.name || '');
 
       case 'count':
-        // Handle $count on navigation properties
-        // This generates a subquery to count related records
         return this.buildCountExpression(expression.count);
 
       case 'function':
@@ -445,14 +499,18 @@ export class SequelizerAdaptor {
   private buildCountExpression(countInfo: any): any {
     const { relationType, sourceTable, targetTable, foreignKey, sourceKey } = countInfo;
 
+    // Validate all identifiers used in the subquery
+    this.validateSqlIdentifier(targetTable, 'target table');
+    this.validateSqlIdentifier(sourceTable, 'source table');
+    this.validateSqlIdentifier(foreignKey, 'foreign key');
+    this.validateSqlIdentifier(sourceKey, 'source key');
+
     // Build the subquery based on the relation type
     let subquery: string;
 
     if (relationType === 'hasMany' || relationType === 'belongsToMany') {
-      // For HasMany: SELECT COUNT(*) FROM related_table WHERE related_table.foreign_key = parent_table.primary_key
       subquery = `(SELECT COUNT(*) FROM "${targetTable}" WHERE "${targetTable}"."${foreignKey}" = "${sourceTable}"."${sourceKey}")`;
     } else if (relationType === 'belongsTo' || relationType === 'hasOne') {
-      // For BelongsTo/HasOne: This would always be 0 or 1, but we support it anyway
       subquery = `(SELECT COUNT(*) FROM "${targetTable}" WHERE "${targetTable}"."${sourceKey}" = "${sourceTable}"."${foreignKey}")`;
     } else {
       throw new BadRequestError(`Unsupported relation type for $count: ${relationType}`);
@@ -475,26 +533,31 @@ export class SequelizerAdaptor {
           return 'NULL';
         }
         if (typeof value === 'string') {
-          return `'${value.replace(/'/g, "''")}'`; // Escape single quotes
+          return this.escapeSqlString(value);
         }
-        if (typeof value === 'number' || typeof value === 'boolean') {
+        if (typeof value === 'number') {
+          return this.validateSqlNumber(value);
+        }
+        if (typeof value === 'boolean') {
           return String(value);
         }
-        return String(value);
+        throw new BadRequestError(`Unsupported literal value type: ${typeof value}`);
 
       case 'field':
         // Check if this is a navigation path field
         if (expression.field?.navigationPath && expression.field?.table) {
-          // Use table alias and column name for joined tables
-          const alias = expression.field.navigationPath[0]; // Navigation property name
+          const alias = expression.field.navigationPath[0];
           const columnName = expression.field.name;
+          this.validateSqlIdentifier(alias, 'navigation property');
+          this.validateSqlIdentifier(columnName, 'column name');
           return `"${alias}"."${columnName}"`;
         }
         // Return quoted column name for simple fields
-        return `"${expression.field?.name || ''}"`;
+        const fieldName = expression.field?.name || '';
+        this.validateSqlIdentifier(fieldName, 'column name');
+        return `"${fieldName}"`;
 
       case 'count':
-        // Handle $count in SQL string context
         return this.countToSql(expression.count);
 
       case 'function':
@@ -513,6 +576,12 @@ export class SequelizerAdaptor {
    */
   private countToSql(countInfo: any): string {
     const { relationType, sourceTable, targetTable, foreignKey, sourceKey } = countInfo;
+
+    // Validate all identifiers used in the subquery
+    this.validateSqlIdentifier(targetTable, 'target table');
+    this.validateSqlIdentifier(sourceTable, 'source table');
+    this.validateSqlIdentifier(foreignKey, 'foreign key');
+    this.validateSqlIdentifier(sourceKey, 'source key');
 
     // Build the subquery based on the relation type
     if (relationType === 'hasMany' || relationType === 'belongsToMany') {
@@ -589,10 +658,25 @@ export class SequelizerAdaptor {
         return `CEIL(${args[0]})`;
       case 'cast':
         // OData V4 cast(expression, type) -> SQL CAST(expression AS type)
-        // Note: The type argument in OData is a string literal, which will be quoted in expressionToSql.
-        // We need to unquote it.
-        const typeArg = args[1].replace(/^'|'$/g, '');
-        return `CAST(${args[0]} AS ${typeArg})`;
+        // Validate the type argument against a strict allowlist to prevent SQL injection.
+        const ALLOWED_CAST_TYPES = [
+          'int', 'integer', 'bigint', 'smallint', 'tinyint',
+          'float', 'real', 'double', 'double precision',
+          'decimal', 'numeric',
+          'varchar', 'char', 'text', 'nvarchar', 'nchar', 'ntext',
+          'date', 'time', 'datetime', 'datetime2', 'timestamp', 'timestamptz',
+          'boolean', 'bool', 'bit',
+          'uuid', 'guid',
+          'json', 'jsonb',
+          'binary', 'varbinary', 'blob',
+        ];
+        const rawTypeArg = args[1].replace(/^'|'$/g, '').trim().toLowerCase();
+        // Also allow types with precision like decimal(10,2) or varchar(255)
+        const baseType = rawTypeArg.replace(/\([\d,\s]+\)$/, '');
+        if (!ALLOWED_CAST_TYPES.includes(baseType)) {
+          throw new BadRequestError(`Invalid CAST type: ${rawTypeArg}. Allowed types: ${ALLOWED_CAST_TYPES.join(', ')}`);
+        }
+        return `CAST(${args[0]} AS ${rawTypeArg})`;
       default:
         throw new BadRequestError(`Unsupported function: ${func.name}`);
     }


### PR DESCRIPTION
## Summary

- Add input validation for all SQL identifiers (table names, column names, aliases) interpolated into `literal()` strings using a strict regex pattern
- Add safe string escaping (`escapeSqlString`) with null byte rejection for string literals in SQL
- Add numeric validation (`validateSqlNumber`) to reject NaN/Infinity values
- Restrict `has` operator to simple field-to-integer comparisons (was previously passing unsanitized values to `literal()`)
- Add CAST type allowlist to prevent injection via `cast()` function arguments
- Escape LIKE wildcards (`%`, `_`, `\`) in `contains`/`startswith`/`endswith` to prevent wildcard injection
- Fix `notLike` pattern handling (was broken by inline `NOT LIKE` prefix in pattern string)

## Motivation

Several paths in `sequelizer.ts` interpolate user-controlled values directly into SQL strings via Sequelize's `literal()` function, bypassing Sequelize's parameterized query protections. This enables SQL injection through:

1. **Arithmetic expressions** — `$filter=Price add 1 gt 100` passes operands through `expressionToSql()` → `arithmeticToSql()` into `literal()`
2. **Cast type arguments** — `cast(field, 'arbitrary SQL')` passes the type string directly to `CAST(... AS ...)`
3. **Has operator** — `flags has <value>` passes both sides unsanitized into `literal()`
4. **Count subqueries** — `buildCountExpression()` and `countToSql()` interpolate table/column names into subqueries
5. **Navigation path fields** — `$alias.column$` patterns interpolated without validation

## Test plan

- [ ] Unit tests pass with no regressions
- [ ] Verify that valid OData queries with arithmetic, cast, has, contains, startswith, endswith still work correctly
- [ ] Verify that malicious inputs (SQL in field names, cast types, has values) are rejected with 400 errors