### PR TITLE
Bump minimum Node.js version from 14 to 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "homepage": "https://github.com/Phrasecode/odata#readme",
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=18.0.0"
   },
   "peerDependencies": {
     "express": "^4.0.0",


### PR DESCRIPTION
## Summary

- Update `engines.node` from `>=14.0.0` to `>=18.0.0`

## Motivation

Node 14 (EOL April 2023) and Node 16 (EOL September 2023) are no longer maintained. The `better-sqlite3` devDependency requires Node 20+, and Sequelize 6.37 uses features available in Node 18+. This aligns the declared minimum with the actual runtime requirements.

## Test plan

- [x] Verify `npm install` and `npm test` pass on Node 18, 20, and 22